### PR TITLE
use apt-get instead of apk

### DIFF
--- a/clients/reth/Dockerfile
+++ b/clients/reth/Dockerfile
@@ -2,7 +2,8 @@ ARG branch=main
 FROM paradigmxyz/reth:$branch
 
 # Install script tools.
-RUN apk add --update bash curl jq
+RUN apt-get update -y
+RUN apt-get install -y bash curl jq
 
 # Add genesis mapper script.
 ADD genesis.json /genesis.json


### PR DESCRIPTION
The underlying reth image is now ubuntu, so this updates how we download packages